### PR TITLE
Remove multiplication by 2 when calculating how much space to allocate in decode-mp3-file.

### DIFF
--- a/mpg123.lisp
+++ b/mpg123.lisp
@@ -913,7 +913,7 @@ artist, album, year, comment, tack, and genre as a property list."
              (mpg123-format handle rate 2 MPG123_ENC_UNSIGNED_16)
              (mpg123-scan handle)
              (let* ((length (* channels (mpg123-length handle)))
-                    (buffer (make-array (* 2 length) :element-type '(signed-byte 16))))
+                    (buffer (make-array length :element-type '(signed-byte 16))))
                (with-foreign-objects ((nread 'size_t)
                                       (cbuffer :short 16384))
                  (loop as err = (mpg123-read handle cbuffer 32768 nread)


### PR DESCRIPTION
I was seeing a problem where all of the mp3 files I loaded with (mpg123:decode-mp3-file "...") were returning 2x the number of samples I expected, with the second half of the sample array containing only 0s.

Removing this multiply by 2 solves the problem, and I don't see any cases where it would be needed.