### PR TITLE
Don't raise on Vorbis error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+<p>Mixalot is a collection of systems related to audio in Common Lisp,
+under an MIT-style license. Currently it consists of a mixer component
+providing real-time audio output on Linux (via ALSA) and other
+platforms (using <a href="http://xiph.org/ao/">libao</a>),
+<a href="http://common-lisp.net/project/cffi/">CFFI</a> bindings to
+the <a href="http://www.mpg123.de/api/">libmpg123</a>, <a href="http://flac.sourceforge.net/">libFLAC</a>,
+and <a href="http://xiph.org/vorbis/doc/vorbisfile/index.html">libvorbisfile</a>
+libraries, and audio stream classes for simple playback of MP3, Ogg,
+and FLAC files through the mixer.</p>
+
+The documentation is available at [http://vintage-digital.com/hefner/software/mixalot/mixalot.html](http://vintage-digital.com/hefner/software/mixalot/mixalot.html)
+
+This library is for example used in the
+[Shuffletron](https://github.com/ahefner/shuffletron/) music player.
+
+<!--  ----------------------------------------------------------------- -->
+<h2><a name="Installation"></a>Installation</h2>
+
+<p>The most recent development version of Mixalot is hosted on <a href="http://github.com/ahefner/mixalot">github</a> and can be obtained as follows:</p>
+<pre class="lisp">
+git clone git://github.com/ahefner/mixalot.git</pre>
+
+<p>Mixalot includes several ASDF systems which should be symlinked into the ASDF central registry in the usual fashion. It depends directly on the following systems:</p>
+<ul>
+  <li>CFFI</li>
+  <li>bordeaux-threads</li>
+  <li>Alexandria</li>
+</ul>
+
+<p>You may find this library useful for the following purposes:</p>
+<ul>
+  <li>Audio output, if you aren't overly concerned with latency</li>
+  <li>Playing MP3, Ogg, or FLAC files</li>
+  <li>Decoding audio files to a vector in memory</li>
+  <li>Querying ID3 tags from MP3 files</li>
+  <li>Querying tags from FLAC and Ogg Vorbis files</li>
+</ul>
+
+
+<!--  ----------------------------------------------------------------- -->
+<h2><a name="Portability"></a>Portability</h2>
+
+<p>The CFFI and bordeaux-threads libraries are used to ease porting
+between lisp implementations. The mixer component of Mixalot chooses
+at compile time to use ALSA (on Linux)
+or <a href="http://xiph.org/ao/">libao</a> (everywhere else) and
+should be able to produce audio on any platform supported by libao. In
+order to be useful in an application, the mixer must also run in its
+own (native) thread.  Therefore, the <tt>mixalot</tt>
+and <tt>mixalot-mp3</tt> systems should be usable on CL
+implementations capable of running multiple threads, on Linux or
+platforms supported by libao. It has been tested and is known to work
+in the following configurations:</p>
+<ul>
+  <li>SBCL (w/sb-thread enabled) on Linux/x86 and Linux/x86-64</li>
+  <li>SBCL (w/sb-thread enabled) on Mac OS X 10.6.3 (x86_64)</li>
+  <li>SBCL (w/sb-thread enabled) on FreeBSD 8.2 (amd64)</li>
+  <li>Clozure CL on Linux/x86_64</li>
+</ul>
+<p>The <tt>mpg123-ffi</tt> system is independent and should be usable on any CL supported by CFFI.</p>

--- a/vorbis-stream.lisp
+++ b/vorbis-stream.lisp
@@ -36,12 +36,12 @@
             ;; XXX DUBIOUS
             (unless (= output-rate rate)
               #+NIL
-              (raise-vorbis-error "Open Ogg Vorbis file"
+              (warn-vorbis-error "Open Ogg Vorbis file"
                                   "Sample rate doesn't match requested rate.")
               (warn "Sample rate doesn't match requested rate: ~:D vs expected ~:D"
                     rate output-rate))
             (unless (or (= channels 2) (= channels 1))
-              (raise-vorbis-error "Open Ogg Vorbis file"
+              (warn-vorbis-error "Open Ogg Vorbis file"
                                   "Vorbis file is not mono or stereo."))
             (rotatef handle uhandle))
           (when uhandle (vorbis-close uhandle))))

--- a/vorbisfile-package.lisp
+++ b/vorbisfile-package.lisp
@@ -3,7 +3,7 @@
   (:export #:vorbis-error
            #:vorbis-strerror
            #:check-vorbis-error
-           #:raise-vorbis-error
+           #:warn-vorbis-error
 
            #:vorbis-new
            #:vorbis-delete

--- a/vorbisfile.lisp
+++ b/vorbisfile.lisp
@@ -147,23 +147,22 @@
 (defun vorbis-strerror (result)
   (cdr (assoc result *vorbis-strerror* :test #'eql)))
 
-(defun raise-vorbis-error (circumstance message)
-  "Raise an error for the vorbisfile library. Circumstance is a string
-  that describes the circumstance under which this error was raised, and
-  message is a string that (tries to) explain the error."
-  (error 'vorbis-error
-         :text (format nil "~A: ~A" circumstance message)))
+(defun warn-vorbis-error (circumstance message)
+  "Warn for an error for the vorbisfile library. Circumstance is a string
+  that describes the circumstance under which this warning was raised, and
+  message is a string that (tries to) explain it."
+  (warn "~A: ~A" circumstance message))
 
 (defun check-vorbis-error (circumstance result)
   "Check if an error has occured in the vorbisfile library calls."
   (when (< result 0)
-    (raise-vorbis-error circumstance
+    (warn-vorbis-error circumstance
                         (vorbis-strerror result))))
 
 (defun check-vorbis-pointer-error (circumstance pointer)
   "Check if an error has occured in the vorbisfile library calls pertaining to a pointer."
   (if (null-pointer-p pointer)
-    (raise-vorbis-error circumstance
+    (warn-vorbis-error circumstance
                         "Operation performed on invalid physical or logical stream.")
     pointer))
 


### PR DESCRIPTION
`warn` was used in `voribis-stream.lisp`:

```
            (unless (= output-rate rate)
              #+NIL
              (raise-vorbis-error "Open Ogg Vorbis file"
                                  "Sample rate doesn't match requested rate.")
              (warn "Sample rate doesn't match requested rate: ~:D vs expected ~:D"
                    rate output-rate))
```

I can scan my library, but I won't find the problematic file(s) and I don't see the warning messages…

I added a readme ;)