### PR TITLE
Add loading of libao and libmpg123 dll files for windows

### DIFF
--- a/mixalot.lisp
+++ b/mixalot.lisp
@@ -92,7 +92,8 @@
 (in-package :mixalot)
 
 (eval-when (:compile-toplevel)
-  #-linux (pushnew 'use-ao *features*)
+;;;; "The mixer component of Mixalot chooses at compile time to use ALSA (on Linux) or libao (everywhere else)" From page: http://vintage-digital.com/hefner/software/mixalot/mixalot.html in section "Portability"
+  #-linux (pushnew 'use-ao *features*) 
   #+linux (pushnew 'use-alsa *features*))
 
 (deftype array-index ()

--- a/mixalot.lisp
+++ b/mixalot.lisp
@@ -91,8 +91,8 @@
 
 (in-package :mixalot)
 
+;;; The mixer component of Mixalot chooses at compile time to use ALSA (on Linux) or libao (everywhere else)
 (eval-when (:compile-toplevel)
-;;;; "The mixer component of Mixalot chooses at compile time to use ALSA (on Linux) or libao (everywhere else)" From page: http://vintage-digital.com/hefner/software/mixalot/mixalot.html in section "Portability"
   #-linux (pushnew 'use-ao *features*) 
   #+linux (pushnew 'use-alsa *features*))
 

--- a/mixalot.lisp
+++ b/mixalot.lisp
@@ -260,6 +260,7 @@
 #+mixalot::use-ao
 (define-foreign-library libao
   (:darwin (:or "libao.4.dylib" "/opt/local/lib/libao.4.dylib"))
+  (:os-windows (:or "libao-4.dll"))
   (t (:or "libao.so")))
 
 #+mixalot::use-ao (use-foreign-library libao)

--- a/mpg123.lisp
+++ b/mpg123.lisp
@@ -182,6 +182,7 @@
               "libmpg123.so.0"
               "/usr/lib/libmpg123.so"
               "/usr/local/lib/libmpg123.so"))
+  (:os-windows (:or "libmpg123-0.dll"))
   (t (:default "libmpg123")))
 
 (use-foreign-library libmpg123)


### PR DESCRIPTION
Hi, Thank you for making this library. It worked nicely out of the box with linux!

For Windows I made some changes:
Added libmpg123-0.dll to be loaded.
I downloaded libmpg from http://www.mpg123.org/download/win32/1.25.13/ and the dll file was apparently named a bit differently than in darwin or the generic name.

Added libao-4.dll to be loaded:
For libao I downloaded the dll for windows using winbuilds (http://win-builds.org/doku.php/download_and_installation_from_windows). There the libao file was named libao-4.dll so I added that as well.
