### PR TITLE
Checks result of ao-open-live function

### DIFF
--- a/mixalot.lisp
+++ b/mixalot.lisp
@@ -304,9 +304,13 @@
            (ao-fmt-rate fmt) rate
            (ao-fmt-byte-format fmt) AO_FMT_LITTLE
            (ao-fmt-matrix fmt) matrix)
-    (ao-open-live (ao-default-driver-id)
-                   fmt
-                   (null-pointer)))))
+      (let ((device (ao-open-live (ao-default-driver-id)
+                                  fmt
+                                  (null-pointer))))
+        (when (null-pointer-p device)
+          ;; TODO: see errno via CFFI-grovel.
+          (error "libao ao-open-live failed."))
+        device))))
 
 #+mixalot::use-ao
 (defun main-thread-init ()


### PR DESCRIPTION
I am trying to use your mixalot on libao environment. 

When I called `create-mixer` with unavailable sample rate like `-1`, I saw messages "libao error." are written endlessly.

```
y2q-no-MacBook-Air-3:mixalot$ sbcl
This is SBCL 2.1.3, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
* (ql:quickload :mixalot)
To load "mixalot":
  Load 1 ASDF system:
    mixalot
; Loading "mixalot"
..................................................
[package mixalot].............
(:MIXALOT)
* (mixalot:main-thread-init)
* (mixalot:create-mixer :rate -1)
ao_macosx ERROR: AudioUnitSetProperty error => -10868
#S(MIXALOT:MIXER
   :STREAM-LOCK #<SB-THREAD:MUTEX "Mixer lock" (free)>
   :STREAM-LIST NIL
   :CURRENT-TIME 0
   :RATE -1
   :SHUTDOWN-FLAG NIL
   :STREAM-STATE #<HASH-TABLE :TEST EQL :COUNT 0 {10049536E3}>
   :DEVICE #.(SB-SYS:INT-SAP #X00000000))
* libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao error.libao erro

(...omitted)
```

I think you should check the result of `ao-open-live` function.
This pull request adds the check, and throws `simple-error` if failed.

([We should see `errno`](https://xiph.org/ao/doc/ao_open_live.html) for handling the error more properly. 
But this PR does not do so because it requires CFFI wrapper, like [osicat library does](https://github.com/osicat/osicat/blob/e635611710fe053b4bbb7e8cc950a524f6061562/posix/wrappers.lisp#L161-L166). It is hard work for me...)
